### PR TITLE
fix: update company visibility logic on companies page

### DIFF
--- a/src/app/components/pages/companies/companies.component.html
+++ b/src/app/components/pages/companies/companies.component.html
@@ -20,9 +20,8 @@
     <h2 class="alt-font">USKORO!</h2>
   </div>
 
-    <h3 class="alt-font">USKORO!</h3>
 
-    <div *ngIf="!showCompanies" class="max-width-1200 auto-margin content">
+    <div *ngIf="showCompanies" class="max-width-1200 auto-margin content">
     <div
       class="auto-margin stretch-width my-5 py-5"
       *ngIf="companies.length == 0"
@@ -32,7 +31,7 @@
 
     <div *ngIf="companies.length != 0" class="has-text-centered">
       <h3>Ekskluzivni pokrovitelj</h3>
-      <p *ngIf="exclusiveCompany.name != ''" class="my-5">Uskoro!</p>
+<!--      <p *ngIf="exclusiveCompany.name !== ''" class="my-5">Uskoro!</p>-->
       <div
         class="exclusive-card company-card"
       >
@@ -41,17 +40,17 @@
         ></exclusive-company-card>
       </div>
 
-      <h3>Dijamantni pokrovitelj</h3>
-      <div>
-        <p *ngIf="diamondCompanies.length == 0" class="my-5">Uskoro!</p>
-        <div class="company-card" *ngFor="let company of diamondCompanies">
-          <diamond-company-card [company]="company"></diamond-company-card>
-        </div>
-      </div>
+<!--      <h3>Dijamantni pokrovitelj</h3>-->
+<!--      <div>-->
+<!--        <p *ngIf="diamondCompanies.length == 0" class="my-5">Uskoro!</p>-->
+<!--        <div class="company-card" *ngFor="let company of diamondCompanies">-->
+<!--          <diamond-company-card [company]="company"></diamond-company-card>-->
+<!--        </div>-->
+<!--      </div>-->
 
       <h3>Platinum pokrovitelji</h3>
       <div>
-        <p *ngIf="platinumCompanies.length != 0" class="my-5">Uskoro!</p>
+<!--        <p *ngIf="platinumCompanies.length != 0" class="my-5">Uskoro!</p>-->
         <div class="company-card" *ngFor="let company of platinumCompanies">
           <platinum-company-card [company]="company"></platinum-company-card>
         </div>
@@ -59,7 +58,7 @@
 
       <h3>Zlatni pokrovitelji</h3>
       <div>
-        <p *ngIf="goldCompanies.length != 0" class="my-5">Uskoro!</p>
+<!--        <p *ngIf="goldCompanies.length != 0" class="my-5">Uskoro!</p>-->
         <div class="company-card" *ngFor="let company of goldCompanies">
           <gold-company-card [company]="company"></gold-company-card>
         </div>
@@ -67,7 +66,7 @@
 
       <h3>Srebrni pokrovitelji</h3>
       <div>
-        <p *ngIf="silverCompanies.length != 0" class="my-5">Uskoro!</p>
+<!--        <p *ngIf="silverCompanies.length != 0" class="my-5">Uskoro!</p>-->
         <div class="company-card" *ngFor="let company of silverCompanies">
           <silver-company-card [company]="company"></silver-company-card>
         </div>
@@ -75,7 +74,7 @@
 
       <h3>Bronzani pokrovitelji</h3>
       <div>
-        <p *ngIf="bronzeCompanies.length != 0" class="my-5">Uskoro!</p>
+<!--        <p *ngIf="bronzeCompanies.length != 0" class="my-5">Uskoro!</p>-->
         <div class="company-card" *ngFor="let company of bronzeCompanies">
           <bronze-company-card [company]="company"></bronze-company-card>
         </div>

--- a/src/app/components/pages/landing-page/landing-page.component.html
+++ b/src/app/components/pages/landing-page/landing-page.component.html
@@ -18,7 +18,7 @@
       </div>
     </div>
 
-<p class="title-description">Vreme do početka sajma:</p>    
+<p class="title-description">Vreme do početka sajma:</p>
 <div class="countdown-grid">
       <div class="countdown-card">
         <span class="countdown-number">{{ countdown.days | number:'2.0-0' }}</span>
@@ -65,7 +65,7 @@
 
 <section class="stats">
   <div>
-    <h2>19</h2>
+    <h2>20</h2>
     <p><b>Godina postojanja</b></p>
   </div>
   <div>
@@ -85,14 +85,17 @@
     </div>
     <div class="text-content">
       <h2>AKADEMSKI PROGRAM</h2>
-      <p>U okviru KONTEH-a, Akademski dani predstavljaju novi segment posvećen dodatnom
-        profesionalnom usavršavanju studenata.
-        Ovaj deo programa obuhvata <b>predavanja, panel diskusiju i radionice</b> o aktuelnim temama u IT industriji kao
-        što su veštačka inteligencija,
-        blockchain tehnologija, razvoj igara i mnoge druge. <br><br>Pored toga, organizuju se <b>takmičenja</b> u kojima
-        studenti
-        imaju priliku da se oprobaju u različitim veštinama računarstva, upoznajući se sa kompanijama i stičući
-        dragoceno iskustvo.</p>
+      <p>
+        U okviru KONTEH-a, Akademski dani predstavljaju novi segment posvećen
+        dodatnom profesionalnom usavršavanju studenata. Program je dizajniran da
+        pruži dubok uvid u aktuelne tehnološke trendove - od primenjene veštačke
+        inteligencije i razvoja video igara do arhitekture kompleksnih inženjerskih sistema,
+        kroz formate keynote <b>predavanja</b>, <b>tematskih track-ova</b> i <b>panel diskusija</b>.
+        <br /> <br />
+        Pored toga, organizuje se <b>algoritamsko takmičenje</b> gde studenti imaju priliku
+        da se oprobaju u različitim veštinama računarstva, upoznajući se sa
+        kompanijama i stičući dragoceno iskustvo.
+      </p>
     </div>
 
   </div>


### PR DESCRIPTION
This pull request updates the `companies.component.html` to adjust when and how company sponsor sections are displayed. The main changes involve fixing the logic that determines when companies are shown and commenting out placeholder messages for upcoming sponsors in various categories.

Display logic and placeholder updates:

* Corrected the condition to display the companies section by changing `*ngIf="!showCompanies"` to `*ngIf="showCompanies"`, ensuring companies are shown only when appropriate.
* Commented out the "Uskoro!" (Coming Soon) placeholder for the exclusive sponsor when a name is present, so it no longer displays unnecessarily.
* Commented out the entire diamond sponsor section, temporarily hiding it from the UI.
* Commented out "Uskoro!" placeholders for platinum, gold, silver, and bronze sponsors, so these messages are no longer shown when companies exist in those categories.