### PR TITLE
Fix schedule description rendering

### DIFF
--- a/src/app/components/pages/schedule/schedule-page/schedule-page.component.html
+++ b/src/app/components/pages/schedule/schedule-page/schedule-page.component.html
@@ -40,8 +40,7 @@
     >
     {{descriptionTxt}}
   </h2>
-  <p>{{schedule.content}}</p>
-
+    <p [innerHTML]="renderDescription(schedule.content)"></p>
   <h2>{{lecturerTxt}}</h2>
   <div *ngIf="schedule.lecturers != null" class="lecturer-wraper">
     <div *ngFor="let lecturer of schedule.lecturers; let id = index">

--- a/src/app/components/pages/schedule/schedule-page/schedule-page.component.ts
+++ b/src/app/components/pages/schedule/schedule-page/schedule-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { Schedule } from 'src/app/model/schedule';
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
 
 @Component({
   selector: 'schedule-page',
@@ -32,4 +33,15 @@ export class SchedulePageComponent {
 
   lecturerTxt : String = this.schedule.type == "panel" ? "Panelisti" : "Predavači";
   descriptionTxt : String = this.schedule.type == "panel" ? "O temi" : "Sadržaj predavanja";
+
+
+  renderDescription(content: any): string {
+    if (!content) return '';
+    if (typeof content === 'string') return content;
+    try {
+      return documentToHtmlString(content);
+    } catch {
+      return '';
+    }
+  }
 }


### PR DESCRIPTION
This pull request improves how schedule content is displayed by rendering rich text content safely and correctly on the schedule page. The main change is the introduction of a new method to handle rich text, ensuring that both plain strings and Contentful rich text objects are displayed as intended.

**Rich text rendering improvements:**

* Added the `documentToHtmlString` import from `@contentful/rich-text-html-renderer` to enable conversion of Contentful rich text objects to HTML.
* Introduced the `renderDescription` method in `SchedulePageComponent` to handle both string and Contentful rich text content, returning HTML for display.
* Updated the schedule page template to use `[innerHTML]="renderDescription(schedule.content)"` instead of simple interpolation, allowing for proper HTML rendering of rich text.